### PR TITLE
Improve OG metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
+website: https://geogeeks.org/
 keep_files: [ workshops, geogeeks.ics ]

--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,2 @@
-website: https://geogeeks.org/
+website: https://geogeeks.org
 keep_files: [ workshops, geogeeks.ics ]

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
+    <meta property="og:image" content="{{ site.url }}/assets/img/geogeeks_logo.png" />
     <meta name="author" content="Geogeeks Perth" />
     <title>Geogeeks Perth</title>
     <!-- Favicons -->

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -1,3 +1,8 @@
+{% capture og_description_fallback %}
+{% for desc in site.data.masthead.description %}
+{{desc}}
+{% endfor %}
+{% endcapture %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -6,7 +11,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <meta name="description" content="{{page.description}}" />
+    <meta name="description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
     <meta name="author" content="Geogeeks Perth" />
     <title>Geogeeks Perth</title>
     <!-- Favicons -->

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -12,6 +12,7 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
+    <meta name="og:description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
     <meta property="og:image" content="{{ site.url }}/assets/img/geogeeks_logo.png" />
     <meta name="author" content="Geogeeks Perth" />
     <title>Geogeeks Perth</title>


### PR DESCRIPTION
Works towards #42 adding `description`, `og:description` and `og:image` metadata tags.

Built the website to ensure that `og:description` and `og:image` were set correctly. Feel free to push edits (perhaps choosing another preview image).