### PR TITLE
Change from site.url to site.website

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -13,7 +13,7 @@
     />
     <meta name="description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
     <meta name="og:description" content="{{ page.description | default: og_description_fallback | strip_newlines }}" />
-    <meta property="og:image" content="{{ site.url }}/assets/img/geogeeks_logo.png" />
+    <meta property="og:image" content="{{ site.website }}/assets/img/geogeeks_logo.png" />
     <meta name="author" content="Geogeeks Perth" />
     <title>Geogeeks Perth</title>
     <!-- Favicons -->

--- a/_layouts/ical.ics
+++ b/_layouts/ical.ics
@@ -6,7 +6,7 @@ PRODID:-//{{ site.domain }}//{{ site.title }}//EN
 X-WR-CALNAME:{{site.title}}
 CALSCALE:GREGORIAN{% assign events_data = site.pages | where: "layout", "event" | sort: "path" | reverse %}{% for event in events_data %}
 BEGIN:VEVENT
-URL:{{ event.url | prepend: site.url }}
+URL:{{ event.url | prepend: site.website }}
 UID:{{ event.url | prepend: site.domain }}
 {%- comment -%}
   DTSTAMP is when this file was generated,


### PR DESCRIPTION
This fixes the generated URLs in the icalendar feed and the og:image metadata.

The former doesn't exist in _config.yml, I guess the usage was from when it did.